### PR TITLE
Bean generator refactoring

### DIFF
--- a/common-codegen/build.gradle
+++ b/common-codegen/build.gradle
@@ -4,6 +4,7 @@ plugins {
 
 dependencies {
 
+
     compile "io.vrap.rmf:raml-model:${versions.rmf}"
     compile "org.immutables:value:2.6.1"
     apt "org.immutables:value:2.6.1"
@@ -17,6 +18,10 @@ dependencies {
     compile 'org.joda:joda-beans:2.2.2'
     compile 'com.neovisionaries:nv-i18n:1.17'
     compile 'javax.validation:validation-api:2.0.1.Final'
+
+    testCompile 'com.fasterxml.jackson.module:jackson-module-parameter-names:2.9.5'
+    testCompile 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.9.5'
+    testCompile 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.9.5'
 
     testCompile "org.spockframework:spock-core:${versions.spock}"
     testCompile "org.assertj:assertj-core:3.10.0"

--- a/common-codegen/src/main/java/io/vrap/rmf/codegen/common/generator/core/CodeGenerator.java
+++ b/common-codegen/src/main/java/io/vrap/rmf/codegen/common/generator/core/CodeGenerator.java
@@ -7,7 +7,7 @@ import io.vrap.rmf.raml.model.types.AnyType;
 
 import java.util.Objects;
 
-public abstract class CodeGenerator extends ConfigDecorator {
+public abstract class CodeGenerator extends ConfigDecoratorBase {
 
 
     private final Flowable<AnyType> ramlObjects;

--- a/common-codegen/src/main/java/io/vrap/rmf/codegen/common/generator/core/CodeGenerator.java
+++ b/common-codegen/src/main/java/io/vrap/rmf/codegen/common/generator/core/CodeGenerator.java
@@ -2,70 +2,35 @@ package io.vrap.rmf.codegen.common.generator.core;
 
 import io.reactivex.Flowable;
 import io.reactivex.Single;
-import io.vrap.rmf.codegen.common.generator.doc.JavaDocProcessor;
-import io.vrap.rmf.codegen.common.generator.util.TypeNameSwitch;
 import io.vrap.rmf.raml.model.modules.Api;
 import io.vrap.rmf.raml.model.types.AnyType;
 
-import java.nio.file.Path;
-import java.text.CharacterIterator;
-import java.text.StringCharacterIterator;
-import java.util.Collections;
-import java.util.Map;
 import java.util.Objects;
 
-public abstract class CodeGenerator {
+public abstract class CodeGenerator extends ConfigDecorator {
 
-    private final GeneratorConfig generatorConfig;
 
     private final Flowable<AnyType> ramlObjects;
 
     private final Api api;
 
-    private final TypeNameSwitch typeNameSwitch;
-
-
     public CodeGenerator(GeneratorConfig generatorConfig, Api api) {
-        Objects.requireNonNull(generatorConfig);
-        this.generatorConfig = generatorConfig;
+        super(generatorConfig);
+        Objects.requireNonNull(api);
         this.api = api;
         this.ramlObjects = Flowable.fromIterable(api.getUses()).flatMapIterable(libraryUse -> libraryUse.getLibrary().getTypes());
-        this.typeNameSwitch = TypeNameSwitch.of(getPackagePrefix(), generatorConfig.getCustomTypeMapping());
+
     }
 
     public final Api getApi() {
         return api;
     }
 
-    public String getPackagePrefix() {
-        return getGeneratorConfig().getPackagePrefix();
-    }
-
-    public final Path getOutputFolder() {
-        return getGeneratorConfig().getOutputFolder();
-    }
-
-    public final JavaDocProcessor getJavaDocProcessor() {
-        return getGeneratorConfig().getJavaDocProcessor();
-    }
-
     public final Flowable<AnyType> getRamlObjects() {
         return ramlObjects;
     }
 
-    public final Map<String, String> getCustomTypeMapping() {
-        return getGeneratorConfig().getCustomTypeMapping();
-    }
-
-    public final TypeNameSwitch getTypeNameSwitch() {
-        return typeNameSwitch;
-    }
-
-    public abstract  Single<GenerationResult> generateStub();
-
-    private final GeneratorConfig getGeneratorConfig() {
-        return generatorConfig;
-    }
+    public abstract Single<GenerationResult> generateStub();
 
 
 }

--- a/common-codegen/src/main/java/io/vrap/rmf/codegen/common/generator/core/ConfigDecorator.java
+++ b/common-codegen/src/main/java/io/vrap/rmf/codegen/common/generator/core/ConfigDecorator.java
@@ -1,0 +1,51 @@
+package io.vrap.rmf.codegen.common.generator.core;
+
+import io.vrap.rmf.codegen.common.generator.doc.JavaDocProcessor;
+import io.vrap.rmf.codegen.common.generator.util.TypeNameSwitch;
+
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Objects;
+
+public class ConfigDecorator implements GeneratorConfig{
+
+    private final GeneratorConfig delegate;
+
+    private final TypeNameSwitch typeNameSwitch;
+
+    public ConfigDecorator(final GeneratorConfig delegate) {
+        Objects.requireNonNull(delegate);
+        this.delegate = delegate;
+        this.typeNameSwitch = TypeNameSwitch.of(getPackagePrefix(), getCustomTypeMapping());
+    }
+
+    @Override
+    public String getPackagePrefix() {
+        return delegate.getPackagePrefix();
+    }
+
+    @Override
+    public Path getOutputFolder() {
+        return delegate.getOutputFolder();
+    }
+
+    @Override
+    public Path getRamlFileLocation() {
+        return delegate.getRamlFileLocation();
+    }
+
+    @Override
+    public JavaDocProcessor getJavaDocProcessor() {
+        return delegate.getJavaDocProcessor();
+    }
+
+    @Override
+    public Map<String, String> getCustomTypeMapping() {
+        return delegate.getCustomTypeMapping();
+    }
+
+    public TypeNameSwitch getTypeNameSwitch() {
+        return typeNameSwitch;
+    }
+
+}

--- a/common-codegen/src/main/java/io/vrap/rmf/codegen/common/generator/core/ConfigDecoratorBase.java
+++ b/common-codegen/src/main/java/io/vrap/rmf/codegen/common/generator/core/ConfigDecoratorBase.java
@@ -7,13 +7,13 @@ import java.nio.file.Path;
 import java.util.Map;
 import java.util.Objects;
 
-public class ConfigDecorator implements GeneratorConfig{
+public class ConfigDecoratorBase implements GeneratorConfig{
 
     private final GeneratorConfig delegate;
 
     private final TypeNameSwitch typeNameSwitch;
 
-    public ConfigDecorator(final GeneratorConfig delegate) {
+    public ConfigDecoratorBase(final GeneratorConfig delegate) {
         Objects.requireNonNull(delegate);
         this.delegate = delegate;
         this.typeNameSwitch = TypeNameSwitch.of(getPackagePrefix(), getCustomTypeMapping());

--- a/common-codegen/src/main/java/io/vrap/rmf/codegen/common/generator/model/codegen/BaseClass.java
+++ b/common-codegen/src/main/java/io/vrap/rmf/codegen/common/generator/model/codegen/BaseClass.java
@@ -1,0 +1,69 @@
+package io.vrap.rmf.codegen.common.generator.model.codegen;
+
+import com.squareup.javapoet.*;
+import io.vrap.rmf.codegen.common.generator.core.ConfigDecorator;
+import io.vrap.rmf.codegen.common.generator.core.GeneratorConfig;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+import javax.annotation.Generated;
+import javax.lang.model.element.Modifier;
+
+class BaseClass extends ConfigDecorator {
+
+    private final ClassName className;
+    private final TypeSpec typeSpec;
+
+    public BaseClass(GeneratorConfig delegate) {
+        super(delegate);
+        this.className = ClassName.get(getPackagePrefix() + ".base", "Base");
+        this.typeSpec = createTypeSpec();
+    }
+
+    public ClassName getClassName() {
+        return className;
+    }
+
+
+    public TypeSpec getTypeSpec() {
+       return typeSpec;
+    }
+
+    private TypeSpec createTypeSpec() {
+
+        final MethodSpec toString = MethodSpec.methodBuilder("toString")
+                .addCode("return $T.reflectionToString(this, $T.SHORT_PREFIX_STYLE);\n", ToStringBuilder.class, ToStringStyle.class)
+                .addAnnotation(Override.class)
+                .returns(String.class)
+                .addModifiers(Modifier.PUBLIC)
+                .build();
+
+        final MethodSpec equals = MethodSpec.methodBuilder("equals")
+                .addParameter(ParameterSpec.builder(TypeName.get(Object.class), "o").build())
+                .addCode("return $T.reflectionEquals(this, o);\n", EqualsBuilder.class)
+                .addAnnotation(Override.class)
+                .returns(TypeName.BOOLEAN.unbox())
+                .addModifiers(Modifier.PUBLIC)
+                .build();
+
+        final MethodSpec hashCode = MethodSpec.methodBuilder("hashCode")
+                .addCode("return $T.reflectionHashCode(this);\n", HashCodeBuilder.class)
+                .addAnnotation(Override.class)
+                .returns(TypeName.INT.unbox())
+                .addModifiers(Modifier.PUBLIC)
+                .build();
+
+        final TypeSpec typeSpec = TypeSpec.classBuilder(getClassName())
+                .addModifiers(Modifier.PUBLIC)
+                .addAnnotation(AnnotationSpec.builder(Generated.class).addMember("value","$S",getClass().getCanonicalName() ).build())
+                .addMethod(toString)
+                .addMethod(equals)
+                .addMethod(hashCode)
+                .build();
+
+        return typeSpec;
+
+    }
+}

--- a/common-codegen/src/main/java/io/vrap/rmf/codegen/common/generator/model/codegen/BaseClass.java
+++ b/common-codegen/src/main/java/io/vrap/rmf/codegen/common/generator/model/codegen/BaseClass.java
@@ -1,7 +1,7 @@
 package io.vrap.rmf.codegen.common.generator.model.codegen;
 
 import com.squareup.javapoet.*;
-import io.vrap.rmf.codegen.common.generator.core.ConfigDecorator;
+import io.vrap.rmf.codegen.common.generator.core.ConfigDecoratorBase;
 import io.vrap.rmf.codegen.common.generator.core.GeneratorConfig;
 import io.vrap.rmf.codegen.common.generator.util.CodeGeneratorUtil;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -11,7 +11,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 
 import javax.lang.model.element.Modifier;
 
-class BaseClass extends ConfigDecorator {
+class BaseClass extends ConfigDecoratorBase {
 
     private final ClassName className;
     private final TypeSpec typeSpec;

--- a/common-codegen/src/main/java/io/vrap/rmf/codegen/common/generator/model/codegen/BaseClass.java
+++ b/common-codegen/src/main/java/io/vrap/rmf/codegen/common/generator/model/codegen/BaseClass.java
@@ -3,12 +3,12 @@ package io.vrap.rmf.codegen.common.generator.model.codegen;
 import com.squareup.javapoet.*;
 import io.vrap.rmf.codegen.common.generator.core.ConfigDecorator;
 import io.vrap.rmf.codegen.common.generator.core.GeneratorConfig;
+import io.vrap.rmf.codegen.common.generator.util.CodeGeneratorUtil;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
-import javax.annotation.Generated;
 import javax.lang.model.element.Modifier;
 
 class BaseClass extends ConfigDecorator {
@@ -57,7 +57,7 @@ class BaseClass extends ConfigDecorator {
 
         final TypeSpec typeSpec = TypeSpec.classBuilder(getClassName())
                 .addModifiers(Modifier.PUBLIC)
-                .addAnnotation(AnnotationSpec.builder(Generated.class).addMember("value","$S",getClass().getCanonicalName() ).build())
+                .addAnnotation(CodeGeneratorUtil.getGeneratedAnnotation(this))
                 .addMethod(toString)
                 .addMethod(equals)
                 .addMethod(hashCode)

--- a/common-codegen/src/main/java/io/vrap/rmf/codegen/common/generator/model/codegen/BeanGenerator.java
+++ b/common-codegen/src/main/java/io/vrap/rmf/codegen/common/generator/model/codegen/BeanGenerator.java
@@ -1,50 +1,42 @@
 package io.vrap.rmf.codegen.common.generator.model.codegen;
 
-import com.fasterxml.jackson.annotation.*;
-import com.squareup.javapoet.*;
-import io.reactivex.Flowable;
+import com.squareup.javapoet.JavaFile;
+import com.squareup.javapoet.TypeSpec;
 import io.reactivex.Maybe;
 import io.reactivex.Single;
 import io.vrap.rmf.codegen.common.generator.core.CodeGenerator;
 import io.vrap.rmf.codegen.common.generator.core.GenerationResult;
 import io.vrap.rmf.codegen.common.generator.core.GeneratorConfig;
-import io.vrap.rmf.codegen.common.generator.util.CodeGeneratorUtil;
 import io.vrap.rmf.raml.model.modules.Api;
-import io.vrap.rmf.raml.model.types.*;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
+import io.vrap.rmf.raml.model.types.AnyType;
+import io.vrap.rmf.raml.model.types.ObjectType;
+import io.vrap.rmf.raml.model.types.StringType;
+import io.vrap.rmf.raml.model.types.util.TypesSwitch;
+import org.eclipse.emf.ecore.EObject;
 
-import javax.annotation.Generated;
-import javax.lang.model.element.Modifier;
 import javax.tools.JavaFileObject;
-import javax.validation.constraints.NotNull;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-import static io.vrap.rmf.codegen.common.generator.util.CodeGeneratorUtil.*;
+import static io.vrap.rmf.codegen.common.generator.util.CodeGeneratorUtil.getObjectPackage;
 
 public class BeanGenerator extends CodeGenerator {
+
+    private final BaseClass baseClass;
+    private final TransformerTypeSwitch transformerTypeSwitch = new TransformerTypeSwitch();
 
 
     public BeanGenerator(GeneratorConfig generatorConfig, Api api) {
         super(generatorConfig, api);
+        baseClass=new BaseClass(this);
     }
-
-
 
     @Override
     public Single<GenerationResult> generateStub() {
 
         final Single<GenerationResult> generationResult = getRamlObjects()
+
                 .flatMapMaybe(this::transformToJavaFile)
                 .concatWith(Single.just(getJavaFileForBase()))
                 .doOnNext(javaFile -> javaFile.writeTo(getOutputFolder()))
@@ -56,246 +48,44 @@ public class BeanGenerator extends CodeGenerator {
         return generationResult;
     }
 
-    @Override
-    public String getPackagePrefix() {
-        return super.getPackagePrefix()+".models";
-    }
 
     public Maybe<JavaFile> transformToJavaFile(final AnyType object) {
-        return buildTypeSpec(object).map(typeSpec -> JavaFile.builder(getObjectPackage(getPackagePrefix(), object), typeSpec).build());
+        return transformerTypeSwitch.doSwitch(object).map(typeSpec -> JavaFile.builder(getObjectPackage(getPackagePrefix(), object), typeSpec).build());
 
     }
 
     private JavaFile getJavaFileForBase() {
-        return JavaFile.builder(getBaseClassName().packageName(), getBaseClassTypeSpec()).build();
-    }
-
-    private Maybe<TypeSpec> buildTypeSpec(final AnyType type) {
-
-        final TypeSpec typeSpec;
-        if (getCustomTypeMapping().get(type.getName()) != null) {
-            return Maybe.empty();
-        } else if (type instanceof ObjectType) {
-            typeSpec = buildTypeSpecForObjectType(((ObjectType) type));
-        } else if (type instanceof StringType) {
-            typeSpec = buildTypeSpecForStringType((StringType) type);
-        } else {
-            return Maybe.error(new RuntimeException("unhandled type " + type));
-        }
-
-        return Maybe.just(typeSpec);
-    }
-
-    private TypeSpec buildTypeSpecForStringType(final StringType stringType) {
-        if (!stringType.getEnum().isEmpty()) {
-            TypeSpec.Builder enumBuilder = TypeSpec.enumBuilder(getClassName(getPackagePrefix(), stringType))
-                    .addModifiers(Modifier.PUBLIC)
-                    .addAnnotation(AnnotationSpec.builder(Generated.class).addMember("value","$S",getClass().getCanonicalName() ).build());
-            stringType.getEnum()
-                    .stream()
-                    .map(StringInstance.class::cast)
-                    .map(StringInstance::getValue)
-                    .forEach(value-> addConstantToEnumConstant(enumBuilder,value));
-            enumBuilder.addJavadoc(getJavaDocProcessor().markDownToJavaDoc(stringType));
-            return enumBuilder.build();
-        } else {
-            TypeSpec typeSpec = TypeSpec.classBuilder(getClassName(getPackagePrefix(), stringType))
-                    .addAnnotation(AnnotationSpec.builder(Generated.class).addMember("value","$S",getClass().getCanonicalName() ).build())
-                    .addModifiers(Modifier.PUBLIC)
-                    .superclass(getBaseClassName())
-                    .addJavadoc(getJavaDocProcessor().markDownToJavaDoc(stringType))
-                    .build();
-            return typeSpec;
-        }
+        return JavaFile.builder(baseClass.getClassName().packageName(), baseClass.getTypeSpec()).build();
     }
 
 
-    private void addConstantToEnumConstant(TypeSpec.Builder enumBuilder, final String enumValue) {
-
-        TypeSpec anootationSpec = TypeSpec.anonymousClassBuilder("")
-                .addAnnotation(AnnotationSpec.builder(JsonProperty.class).addMember("value", "$S",enumValue).build())
-                .build();
-
-        enumBuilder.addEnumConstant(CodeGeneratorUtil.toEnumValueName(enumValue), anootationSpec);
-
-    }
-
-
-
-    private TypeSpec buildTypeSpecForObjectType(final ObjectType objectType) {
-
-
-        // object.getPropertyType() return the supper type
-        final ClassName className = getClassName(getPackagePrefix(), objectType);
-        final TypeSpec.Builder typeSpecBuilder = TypeSpec.classBuilder(className)
-                .addAnnotation(AnnotationSpec.builder(Generated.class).addMember("value","$S",getClass().getCanonicalName() ).build())
-                .addJavadoc(getJavaDocProcessor().markDownToJavaDoc(objectType))
-                .addModifiers(Modifier.PUBLIC);
-
-        getDiscriminatorAnnotations(objectType).forEach(typeSpecBuilder::addAnnotation);
-
-
-        //Add super interfaces
-        Optional.of(
-                Optional.ofNullable(objectType.getType())
-                        .map(anyType -> getClassName(getPackagePrefix(), anyType)).orElse(getBaseClassName())
-        )
-                .map(typeSpecBuilder::superclass)
-                .orElse(null);
-
-
-        Flowable.fromIterable(objectType.getProperties())
-                .doOnNext(property -> typeSpecBuilder.addField(getFieldSpec(property)))
-                .doOnNext(property -> typeSpecBuilder.addMethod(getFieldGetter(property)))
-                .doOnNext(property -> typeSpecBuilder.addMethod(getFieldSetter(property)))
-                .blockingSubscribe();
-
-
-        return typeSpecBuilder.build();
-    }
-
-    private FieldSpec getFieldSpec(final Property property) {
-        FieldSpec.Builder builder;
-        if (property.getName().startsWith("/")) {
-            final TypeName valueType = getTypeNameSwitch().doSwitch(property.getType());
-            builder =  FieldSpec.builder(
-                    ParameterizedTypeName.get(ClassName.get(Map.class), ClassName.get(String.class), valueType), "values", Modifier.PRIVATE);
-        } else {
-            final TypeName valueType = getTypeNameSwitch().doSwitch(property.getType());
-            builder = FieldSpec.builder(valueType, property.getName(), Modifier.PRIVATE);
-        }
-        if(property.getRequired()){
-            builder.addAnnotation(NotNull.class);
-        }
-
-        return builder.build();
-
-
-    }
-
-    private MethodSpec getFieldSetter(final Property property) {
-        final FieldSpec fieldSpec = getFieldSpec(property);
-        final MethodSpec.Builder methodSpec;
-
-
-        if (property.getName().startsWith("/")) {
-            methodSpec = MethodSpec.methodBuilder("setValues");
-        } else {
-            methodSpec = MethodSpec.methodBuilder("set" + getPropertyMethodNameSuffix(property));
-        }
-
-        methodSpec.addParameter(fieldSpec.type, fieldSpec.name)
-                .addModifiers(Modifier.PUBLIC)
-                .addCode("this." + fieldSpec.name + " = " + fieldSpec.name + ";\n")
-                .build();
-        return methodSpec.build();
-    }
-
-    private MethodSpec getFieldGetter(final Property property) {
-        FieldSpec fieldSpec = getFieldSpec(property);
-        final MethodSpec.Builder methdBuilder;
-        if (property.getName().startsWith("/")) {
-            methdBuilder = MethodSpec.methodBuilder("values");
-            methdBuilder.addAnnotation(JsonAnySetter.class);
-            methdBuilder.addAnnotation(JsonAnyGetter.class);
-        } else {
-            final String attributePrefix = isBoolean(fieldSpec) ? "is" : "get";
-            methdBuilder = MethodSpec.methodBuilder(attributePrefix + getPropertyMethodNameSuffix(property))
-                    .addAnnotation(AnnotationSpec.builder(JsonProperty.class)
-                            .addMember("value", "$S", property.getName()).build());
-        }
-        methdBuilder.addModifiers(Modifier.PUBLIC)
-                .returns(fieldSpec.type)
-                .addCode("return " + fieldSpec.name + ";\n");
-        return methdBuilder.build();
-    }
-
-
-    private static String getPropertyMethodNameSuffix(final Property property) {
-        final String javaPropertyName = Arrays.stream(property.getName().split("_"))
-                .map(StringUtils::capitalize)
-                .collect(Collectors.joining());
-
-        return javaPropertyName;
-    }
-
-    private static boolean isBoolean(FieldSpec fieldSpec) {
-        return fieldSpec.type.equals(ClassName.BOOLEAN.box()) || fieldSpec.type.equals(ClassName.BOOLEAN);
-    }
-
-    public Path getPath(JavaFileObject javaFile, Path outputFolder) {
+    private Path getPath(JavaFileObject javaFile, Path outputFolder) {
         return Paths.get(outputFolder.toString(), javaFile.getName());
     }
 
-    protected Stream<AnnotationSpec> getDiscriminatorAnnotations(final ObjectType objectType) {
-        if (StringUtils.isEmpty(objectType.getDiscriminator()) || objectType.getSubTypes().isEmpty()) {
-            return Stream.empty();
-        }
-        final AnnotationSpec jsonTypeInfoAnnotation = AnnotationSpec.builder(JsonTypeInfo.class)
-                .addMember("use", "$T.NAME", JsonTypeInfo.Id.class)
-                .addMember("include", "$T.PROPERTY", JsonTypeInfo.As.class)
-                .addMember("property", "$S", objectType.getDiscriminator())
-                .addMember("visible", "true")
-                .build();
 
-        CodeBlock.Builder annotationBodyBuilder = CodeBlock.builder();
-        List<ObjectType> children = getSubtypes(objectType).collect(Collectors.toList());
-        if (!children.isEmpty()) {
-            for (int i = 0; i < children.size(); i++) {
-                annotationBodyBuilder.add(
-                        (i == 0 ? "{" : ",") +
-                                "\n@$T(value = $T.class, name = $S)"
-                                + (i == children.size() - 1 ? "\n}" : "")
-                        , JsonSubTypes.Type.class, getClassName(getPackagePrefix(), children.get(i)), children.get(i).getDiscriminatorValue());
+    private class TransformerTypeSwitch extends TypesSwitch<Maybe<TypeSpec>>{
+
+        private ObjectTypeTransformer objectTypeTransformer = new ObjectTypeTransformer(BeanGenerator.this);
+        private StringTypeTransformer stringTypeTransformer = new StringTypeTransformer(BeanGenerator.this);
+
+        @Override
+        public Maybe<TypeSpec> doSwitch(EObject eObject) {
+            if((eObject instanceof AnyType)&&(getCustomTypeMapping().get(((AnyType)eObject).getName()) != null) ){
+                return Maybe.empty();
             }
+            return Optional.ofNullable(super.doSwitch(eObject)).orElse(Maybe.error(new RuntimeException("no TypeSpec transformer found for " + eObject)));
         }
-        final AnnotationSpec jsonSubTypesAnnotation = AnnotationSpec.builder(JsonSubTypes.class)
-                .addMember("value", annotationBodyBuilder.build())
-                .build();
 
-        return Stream.of(jsonSubTypesAnnotation, jsonTypeInfoAnnotation);
-    }
+        @Override
+        public Maybe<TypeSpec> caseStringType(StringType object) {
+            return Maybe.just(stringTypeTransformer.toTypeSpec(object));
+        }
 
-
-    private ClassName getBaseClassName() {
-        return ClassName.get(getPackagePrefix() + ".base", "Base");
-    }
-
-
-    private TypeSpec getBaseClassTypeSpec() {
-
-        final MethodSpec toString = MethodSpec.methodBuilder("toString")
-                .addCode("return $T.reflectionToString(this, $T.SHORT_PREFIX_STYLE);\n", ToStringBuilder.class, ToStringStyle.class)
-                .addAnnotation(Override.class)
-                .returns(String.class)
-                .addModifiers(Modifier.PUBLIC)
-                .build();
-
-        final MethodSpec equals = MethodSpec.methodBuilder("equals")
-                .addParameter(ParameterSpec.builder(TypeName.get(Object.class), "o").build())
-                .addCode("return $T.reflectionEquals(this, o);\n", EqualsBuilder.class)
-                .addAnnotation(Override.class)
-                .returns(TypeName.BOOLEAN.unbox())
-                .addModifiers(Modifier.PUBLIC)
-                .build();
-
-        final MethodSpec hashCode = MethodSpec.methodBuilder("hashCode")
-                .addCode("return $T.reflectionHashCode(this);\n", HashCodeBuilder.class)
-                .addAnnotation(Override.class)
-                .returns(TypeName.INT.unbox())
-                .addModifiers(Modifier.PUBLIC)
-                .build();
-
-        final TypeSpec typeSpec = TypeSpec.classBuilder(getBaseClassName())
-                .addModifiers(Modifier.PUBLIC)
-                .addAnnotation(AnnotationSpec.builder(Generated.class).addMember("value","$S",getClass().getCanonicalName() ).build())
-                .addMethod(toString)
-                .addMethod(equals)
-                .addMethod(hashCode)
-                .build();
-
-        return typeSpec;
-
+        @Override
+        public Maybe<TypeSpec> caseObjectType(ObjectType object) {
+            return Maybe.just(objectTypeTransformer.toTypeSpec(object));
+        }
     }
 
 }

--- a/common-codegen/src/main/java/io/vrap/rmf/codegen/common/generator/model/codegen/BeanGenerator.java
+++ b/common-codegen/src/main/java/io/vrap/rmf/codegen/common/generator/model/codegen/BeanGenerator.java
@@ -74,7 +74,7 @@ public class BeanGenerator extends CodeGenerator {
             if((eObject instanceof AnyType)&&(getCustomTypeMapping().get(((AnyType)eObject).getName()) != null) ){
                 return Maybe.empty();
             }
-            return Optional.ofNullable(super.doSwitch(eObject)).orElse(Maybe.error(new RuntimeException("no TypeSpec transformer found for " + eObject)));
+            return Optional.ofNullable(super.doSwitch(eObject)).orElse(Maybe.error(new RuntimeException("No TypeSpec transformer found for " + eObject)));
         }
 
         @Override

--- a/common-codegen/src/main/java/io/vrap/rmf/codegen/common/generator/model/codegen/ObjectTypeTransformer.java
+++ b/common-codegen/src/main/java/io/vrap/rmf/codegen/common/generator/model/codegen/ObjectTypeTransformer.java
@@ -1,0 +1,168 @@
+package io.vrap.rmf.codegen.common.generator.model.codegen;
+
+import com.fasterxml.jackson.annotation.*;
+import com.squareup.javapoet.*;
+import io.reactivex.Flowable;
+import io.vrap.rmf.codegen.common.generator.core.GeneratorConfig;
+import io.vrap.rmf.raml.model.types.ObjectType;
+import io.vrap.rmf.raml.model.types.Property;
+import org.apache.commons.lang3.StringUtils;
+
+import javax.annotation.Generated;
+import javax.lang.model.element.Modifier;
+import javax.validation.constraints.NotNull;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static io.vrap.rmf.codegen.common.generator.util.CodeGeneratorUtil.getClassName;
+import static io.vrap.rmf.codegen.common.generator.util.CodeGeneratorUtil.getSubtypes;
+
+public class ObjectTypeTransformer extends TypeTransformer<ObjectType> {
+
+    private final BaseClass baseClass;
+
+    public ObjectTypeTransformer(GeneratorConfig generatorConfig) {
+        super(generatorConfig);
+        baseClass = new BaseClass(this);
+    }
+
+
+    @Override
+    public TypeSpec toTypeSpec(ObjectType type) {
+        return buildTypeSpecForObjectType(type);
+    }
+
+    private TypeSpec buildTypeSpecForObjectType(final ObjectType objectType) {
+
+
+        // object.getPropertyType() return the supper type
+        final ClassName className = getClassName(getPackagePrefix(), objectType);
+        final TypeSpec.Builder typeSpecBuilder = TypeSpec.classBuilder(className)
+                .addAnnotation(AnnotationSpec.builder(Generated.class).addMember("value","$S",getClass().getCanonicalName() ).build())
+                .addJavadoc(getJavaDocProcessor().markDownToJavaDoc(objectType))
+                .addModifiers(Modifier.PUBLIC);
+
+        getDiscriminatorAnnotations(objectType).forEach(typeSpecBuilder::addAnnotation);
+
+        //Add super interfaces
+        Optional.of(
+                Optional.ofNullable(objectType.getType())
+                        .map(anyType -> getClassName(getPackagePrefix(), anyType)).orElse(baseClass.getClassName())
+        )
+                .map(typeSpecBuilder::superclass)
+                .orElse(null);
+
+        Flowable.fromIterable(objectType.getProperties())
+                .doOnNext(property -> typeSpecBuilder.addField(getFieldSpec(property)))
+                .doOnNext(property -> typeSpecBuilder.addMethod(getFieldGetter(property)))
+                .doOnNext(property -> typeSpecBuilder.addMethod(getFieldSetter(property)))
+                .blockingSubscribe();
+
+
+        return typeSpecBuilder.build();
+    }
+
+    private FieldSpec getFieldSpec(final Property property) {
+        FieldSpec.Builder builder;
+        if (property.getName().startsWith("/")) {
+            final TypeName valueType = getTypeNameSwitch().doSwitch(property.getType());
+            builder =  FieldSpec.builder(
+                    ParameterizedTypeName.get(ClassName.get(Map.class), ClassName.get(String.class), valueType), "values", Modifier.PRIVATE);
+        } else {
+            final TypeName valueType = getTypeNameSwitch().doSwitch(property.getType());
+            builder = FieldSpec.builder(valueType, property.getName(), Modifier.PRIVATE);
+        }
+        if(property.getRequired()){
+            builder.addAnnotation(NotNull.class);
+        }
+
+        return builder.build();
+
+
+    }
+
+    private MethodSpec getFieldSetter(final Property property) {
+        final FieldSpec fieldSpec = getFieldSpec(property);
+        final MethodSpec.Builder methodSpec;
+
+
+        if (property.getName().startsWith("/")) {
+            methodSpec = MethodSpec.methodBuilder("setValues");
+        } else {
+            methodSpec = MethodSpec.methodBuilder("set" + getPropertyMethodNameSuffix(property));
+        }
+
+        methodSpec.addParameter(fieldSpec.type, fieldSpec.name)
+                .addModifiers(Modifier.PUBLIC)
+                .addCode("this." + fieldSpec.name + " = " + fieldSpec.name + ";\n")
+                .build();
+        return methodSpec.build();
+    }
+
+    private MethodSpec getFieldGetter(final Property property) {
+        FieldSpec fieldSpec = getFieldSpec(property);
+        final MethodSpec.Builder methdBuilder;
+        if (property.getName().startsWith("/")) {
+            methdBuilder = MethodSpec.methodBuilder("values");
+            methdBuilder.addAnnotation(JsonAnySetter.class);
+            methdBuilder.addAnnotation(JsonAnyGetter.class);
+        } else {
+            final String attributePrefix = isBoolean(fieldSpec) ? "is" : "get";
+            methdBuilder = MethodSpec.methodBuilder(attributePrefix + getPropertyMethodNameSuffix(property))
+                    .addAnnotation(AnnotationSpec.builder(JsonProperty.class)
+                            .addMember("value", "$S", property.getName()).build());
+        }
+        methdBuilder.addModifiers(Modifier.PUBLIC)
+                .returns(fieldSpec.type)
+                .addCode("return " + fieldSpec.name + ";\n");
+        return methdBuilder.build();
+    }
+
+
+    private static String getPropertyMethodNameSuffix(final Property property) {
+        final String javaPropertyName = Arrays.stream(property.getName().split("_"))
+                .map(StringUtils::capitalize)
+                .collect(Collectors.joining());
+
+        return javaPropertyName;
+    }
+
+    private static boolean isBoolean(FieldSpec fieldSpec) {
+        return fieldSpec.type.equals(ClassName.BOOLEAN.box()) || fieldSpec.type.equals(ClassName.BOOLEAN);
+    }
+
+
+
+    protected Stream<AnnotationSpec> getDiscriminatorAnnotations(final ObjectType objectType) {
+        if (StringUtils.isEmpty(objectType.getDiscriminator()) || objectType.getSubTypes().isEmpty()) {
+            return Stream.empty();
+        }
+        final AnnotationSpec jsonTypeInfoAnnotation = AnnotationSpec.builder(JsonTypeInfo.class)
+                .addMember("use", "$T.NAME", JsonTypeInfo.Id.class)
+                .addMember("include", "$T.PROPERTY", JsonTypeInfo.As.class)
+                .addMember("property", "$S", objectType.getDiscriminator())
+                .addMember("visible", "true")
+                .build();
+
+        CodeBlock.Builder annotationBodyBuilder = CodeBlock.builder();
+        List<ObjectType> children = getSubtypes(objectType).collect(Collectors.toList());
+        if (!children.isEmpty()) {
+            for (int i = 0; i < children.size(); i++) {
+                annotationBodyBuilder.add(
+                        (i == 0 ? "{" : ",") +
+                                "\n@$T(value = $T.class, name = $S)"
+                                + (i == children.size() - 1 ? "\n}" : "")
+                        , JsonSubTypes.Type.class, getClassName(getPackagePrefix(), children.get(i)), children.get(i).getDiscriminatorValue());
+            }
+        }
+        final AnnotationSpec jsonSubTypesAnnotation = AnnotationSpec.builder(JsonSubTypes.class)
+                .addMember("value", annotationBodyBuilder.build())
+                .build();
+
+        return Stream.of(jsonSubTypesAnnotation, jsonTypeInfoAnnotation);
+    }
+}

--- a/common-codegen/src/main/java/io/vrap/rmf/codegen/common/generator/model/codegen/StringTypeTransformer.java
+++ b/common-codegen/src/main/java/io/vrap/rmf/codegen/common/generator/model/codegen/StringTypeTransformer.java
@@ -12,6 +12,7 @@ import javax.annotation.Generated;
 import javax.lang.model.element.Modifier;
 
 import static io.vrap.rmf.codegen.common.generator.util.CodeGeneratorUtil.getClassName;
+import static io.vrap.rmf.codegen.common.generator.util.CodeGeneratorUtil.getGeneratedAnnotation;
 
 public class StringTypeTransformer extends TypeTransformer<StringType> {
 
@@ -28,7 +29,7 @@ public class StringTypeTransformer extends TypeTransformer<StringType> {
         if (!stringType.getEnum().isEmpty()) {
             TypeSpec.Builder enumBuilder = TypeSpec.enumBuilder(getClassName(getPackagePrefix(), stringType))
                     .addModifiers(Modifier.PUBLIC)
-                    .addAnnotation(AnnotationSpec.builder(Generated.class).addMember("value","$S",getClass().getCanonicalName() ).build());
+                    .addAnnotation(getGeneratedAnnotation(this));
             stringType.getEnum()
                     .stream()
                     .map(StringInstance.class::cast)
@@ -38,7 +39,7 @@ public class StringTypeTransformer extends TypeTransformer<StringType> {
             return enumBuilder.build();
         } else {
             TypeSpec typeSpec = TypeSpec.classBuilder(getClassName(getPackagePrefix(), stringType))
-                    .addAnnotation(AnnotationSpec.builder(Generated.class).addMember("value","$S",getClass().getCanonicalName() ).build())
+                    .addAnnotation(getGeneratedAnnotation(this))
                     .addModifiers(Modifier.PUBLIC)
                     .superclass(baseClass.getClassName())
                     .addJavadoc(getJavaDocProcessor().markDownToJavaDoc(stringType))

--- a/common-codegen/src/main/java/io/vrap/rmf/codegen/common/generator/model/codegen/StringTypeTransformer.java
+++ b/common-codegen/src/main/java/io/vrap/rmf/codegen/common/generator/model/codegen/StringTypeTransformer.java
@@ -1,0 +1,59 @@
+package io.vrap.rmf.codegen.common.generator.model.codegen;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.squareup.javapoet.AnnotationSpec;
+import com.squareup.javapoet.TypeSpec;
+import io.vrap.rmf.codegen.common.generator.core.GeneratorConfig;
+import io.vrap.rmf.codegen.common.generator.util.CodeGeneratorUtil;
+import io.vrap.rmf.raml.model.types.StringInstance;
+import io.vrap.rmf.raml.model.types.StringType;
+
+import javax.annotation.Generated;
+import javax.lang.model.element.Modifier;
+
+import static io.vrap.rmf.codegen.common.generator.util.CodeGeneratorUtil.getClassName;
+
+public class StringTypeTransformer extends TypeTransformer<StringType> {
+
+    private final BaseClass baseClass;
+
+    public StringTypeTransformer(GeneratorConfig generatorConfig) {
+        super(generatorConfig);
+        baseClass = new BaseClass(this);
+    }
+
+    @Override
+    public TypeSpec toTypeSpec(StringType stringType) {
+
+        if (!stringType.getEnum().isEmpty()) {
+            TypeSpec.Builder enumBuilder = TypeSpec.enumBuilder(getClassName(getPackagePrefix(), stringType))
+                    .addModifiers(Modifier.PUBLIC)
+                    .addAnnotation(AnnotationSpec.builder(Generated.class).addMember("value","$S",getClass().getCanonicalName() ).build());
+            stringType.getEnum()
+                    .stream()
+                    .map(StringInstance.class::cast)
+                    .map(StringInstance::getValue)
+                    .forEach(value-> addConstantToEnumConstant(enumBuilder,value));
+            enumBuilder.addJavadoc(getJavaDocProcessor().markDownToJavaDoc(stringType));
+            return enumBuilder.build();
+        } else {
+            TypeSpec typeSpec = TypeSpec.classBuilder(getClassName(getPackagePrefix(), stringType))
+                    .addAnnotation(AnnotationSpec.builder(Generated.class).addMember("value","$S",getClass().getCanonicalName() ).build())
+                    .addModifiers(Modifier.PUBLIC)
+                    .superclass(baseClass.getClassName())
+                    .addJavadoc(getJavaDocProcessor().markDownToJavaDoc(stringType))
+                    .build();
+            return typeSpec;
+        }
+    }
+
+    private void addConstantToEnumConstant(TypeSpec.Builder enumBuilder, final String enumValue) {
+
+        TypeSpec anootationSpec = TypeSpec.anonymousClassBuilder("")
+                .addAnnotation(AnnotationSpec.builder(JsonProperty.class).addMember("value", "$S",enumValue).build())
+                .build();
+
+        enumBuilder.addEnumConstant(CodeGeneratorUtil.toEnumValueName(enumValue), anootationSpec);
+
+    }
+}

--- a/common-codegen/src/main/java/io/vrap/rmf/codegen/common/generator/model/codegen/TypeTransformer.java
+++ b/common-codegen/src/main/java/io/vrap/rmf/codegen/common/generator/model/codegen/TypeTransformer.java
@@ -1,0 +1,21 @@
+package io.vrap.rmf.codegen.common.generator.model.codegen;
+
+import com.squareup.javapoet.TypeSpec;
+import io.vrap.rmf.codegen.common.generator.core.ConfigDecorator;
+import io.vrap.rmf.codegen.common.generator.core.GeneratorConfig;
+import io.vrap.rmf.raml.model.types.AnyType;
+
+public abstract class TypeTransformer<T extends AnyType> extends ConfigDecorator {
+
+
+    protected TypeTransformer(final GeneratorConfig generatorConfig) {
+       super(generatorConfig);
+    }
+
+
+    public abstract TypeSpec toTypeSpec(T type);
+
+
+
+
+}

--- a/common-codegen/src/main/java/io/vrap/rmf/codegen/common/generator/model/codegen/TypeTransformer.java
+++ b/common-codegen/src/main/java/io/vrap/rmf/codegen/common/generator/model/codegen/TypeTransformer.java
@@ -1,11 +1,11 @@
 package io.vrap.rmf.codegen.common.generator.model.codegen;
 
 import com.squareup.javapoet.TypeSpec;
-import io.vrap.rmf.codegen.common.generator.core.ConfigDecorator;
+import io.vrap.rmf.codegen.common.generator.core.ConfigDecoratorBase;
 import io.vrap.rmf.codegen.common.generator.core.GeneratorConfig;
 import io.vrap.rmf.raml.model.types.AnyType;
 
-public abstract class TypeTransformer<T extends AnyType> extends ConfigDecorator {
+public abstract class TypeTransformer<T extends AnyType> extends ConfigDecoratorBase {
 
 
     protected TypeTransformer(final GeneratorConfig generatorConfig) {

--- a/common-codegen/src/main/java/io/vrap/rmf/codegen/common/generator/util/CodeGeneratorUtil.java
+++ b/common-codegen/src/main/java/io/vrap/rmf/codegen/common/generator/util/CodeGeneratorUtil.java
@@ -1,5 +1,6 @@
 package io.vrap.rmf.codegen.common.generator.util;
 
+import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.ClassName;
 import io.vrap.rmf.raml.model.modules.Library;
 import io.vrap.rmf.raml.model.types.Annotation;
@@ -9,8 +10,10 @@ import io.vrap.rmf.raml.model.types.StringInstance;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.emf.ecore.EObject;
 
+import javax.annotation.Generated;
 import java.text.CharacterIterator;
 import java.text.StringCharacterIterator;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -59,6 +62,20 @@ public final class CodeGeneratorUtil {
             eContainer = eContainer.eContainer();
         }
         return basePackage;
+    }
+
+    public static AnnotationSpec getGeneratedAnnotation(Class clazz){
+        Objects.requireNonNull(clazz);
+        AnnotationSpec result = AnnotationSpec.builder(Generated.class)
+                .addMember("value","$S",clazz.getCanonicalName() )
+                .addMember("comments","$S","https://github.com/vrapio/rmf-codegen" )
+                .build();
+        return result;
+    }
+
+    public static AnnotationSpec getGeneratedAnnotation(Object object){
+        Objects.requireNonNull(object);
+        return getGeneratedAnnotation(object.getClass());
     }
 
 

--- a/common-codegen/src/main/java/io/vrap/rmf/codegen/common/generator/util/TypeNameSwitch.java
+++ b/common-codegen/src/main/java/io/vrap/rmf/codegen/common/generator/util/TypeNameSwitch.java
@@ -38,11 +38,7 @@ public class TypeNameSwitch extends TypesSwitch<TypeName> {
         if ((eObject instanceof NamedElement) && (getCustomTypeMapping().get(((NamedElement) eObject).getName()) != null)) {
             return ClassName.bestGuess(getCustomTypeMapping().get(((NamedElement) eObject).getName()));
         }
-        final TypeName result = super.doSwitch(eObject);
-        if (result != null) {
-            return result;
-        }
-        return TypeName.get(Object.class);
+        return Optional.ofNullable(super.doSwitch(eObject)).orElse(TypeName.get(Object.class));
     }
 
     @Override


### PR DESCRIPTION
Closes #5 

Now the code generator is separated into smaller blocks, This is just a first step, once the code is mature enough it would be separated into interfaces that contain the logic and that may work for multiple generators.