### PR TITLE
Add publish to bintray

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,8 @@
+# Bintray upload
+
+Set environment variables BINTRAY_USER and BINTRAY_KEY to your bintray credentials.
+Run gradle with
+```
+./gradlew clean build bintrayUpload --info
+```
+to upload the artifacts to the `rmf-codegen` repository in your bintray project.

--- a/build.gradle
+++ b/build.gradle
@@ -105,7 +105,7 @@ subprojects { project ->
 
         pkg {
             repo = 'vrapio'
-            name = 'rmf'
+            name = 'rmf-codegen'
             userOrg = 'vrapio'
             licenses = ['MIT']
             vcsUrl = 'https://github.com/vrapio/rmf-codegen'

--- a/codegen-core/build.gradle
+++ b/codegen-core/build.gradle
@@ -9,9 +9,15 @@ compileTestKotlin {
     kotlinOptions.jvmTarget = "1.8"
 }
 
+publishing {
+    publications {
+        Maven(MavenPublication) {
+            from components.java
+        }
+    }
+}
 
 dependencies {
-
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
     compile 'com.atlassian.commonmark:commonmark:0.11.0'
     compile "io.vrap.rmf:raml-model:${versions.rmf}"
@@ -20,5 +26,4 @@ dependencies {
 
     testCompile "org.assertj:assertj-core:3.10.0"
     testCompile 'junit:junit:4.12'
-
 }

--- a/codegen-renderers/build.gradle
+++ b/codegen-renderers/build.gradle
@@ -1,11 +1,20 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '1.3.41'
 }
+
 compileKotlin {
     kotlinOptions.jvmTarget = "1.8"
 }
 compileTestKotlin {
     kotlinOptions.jvmTarget = "1.8"
+}
+
+publishing {
+    publications {
+        Maven(MavenPublication) {
+            from components.java
+        }
+    }
 }
 
 dependencies {

--- a/languages/javalang/builder-renderer/commercetools-java-base/build.gradle
+++ b/languages/javalang/builder-renderer/commercetools-java-base/build.gradle
@@ -1,8 +1,21 @@
 plugins {
-    id 'java'
+    id 'org.jetbrains.kotlin.jvm' version '1.3.41'
 }
 
-version 'unspecified'
+compileKotlin {
+    kotlinOptions.jvmTarget = "1.8"
+}
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "1.8"
+}
+
+publishing {
+    publications {
+        Maven(MavenPublication) {
+            from components.java
+        }
+    }
+}
 
 dependencies {
     compile 'com.fasterxml.jackson.core:jackson-databind:2.9.9'

--- a/languages/javalang/builder-renderer/commercetools-java-client/build.gradle
+++ b/languages/javalang/builder-renderer/commercetools-java-client/build.gradle
@@ -1,7 +1,21 @@
 plugins {
-    id 'java'
+    id 'org.jetbrains.kotlin.jvm' version '1.3.41'
 }
 
+compileKotlin {
+    kotlinOptions.jvmTarget = "1.8"
+}
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "1.8"
+}
+
+publishing {
+    publications {
+        Maven(MavenPublication) {
+            from components.java
+        }
+    }
+}
 
 dependencies {
 }

--- a/languages/javalang/builder-renderer/generated-code/build.gradle
+++ b/languages/javalang/builder-renderer/generated-code/build.gradle
@@ -1,4 +1,10 @@
-
+publishing {
+    publications {
+        Maven(MavenPublication) {
+            from components.java
+        }
+    }
+}
 
 dependencies {
     compile project(':languages:javalang:builder-renderer:commercetools-java-client')

--- a/languages/javalang/builder-renderer/java-builder-client/build.gradle
+++ b/languages/javalang/builder-renderer/java-builder-client/build.gradle
@@ -1,4 +1,3 @@
-
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '1.3.41'
 }
@@ -6,9 +5,16 @@ plugins {
 compileKotlin {
     kotlinOptions.jvmTarget = "1.8"
 }
-
 compileTestKotlin {
     kotlinOptions.jvmTarget = "1.8"
+}
+
+publishing {
+    publications {
+        Maven(MavenPublication) {
+            from components.java
+        }
+    }
 }
 
 dependencies {

--- a/languages/javalang/java-base/build.gradle
+++ b/languages/javalang/java-base/build.gradle
@@ -1,7 +1,7 @@
-
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '1.3.41'
 }
+
 compileKotlin {
     kotlinOptions.jvmTarget = "1.8"
 }
@@ -9,6 +9,13 @@ compileTestKotlin {
     kotlinOptions.jvmTarget = "1.8"
 }
 
+publishing {
+    publications {
+        Maven(MavenPublication) {
+            from components.java
+        }
+    }
+}
 
 dependencies {
     compile project(':codegen-renderers')

--- a/languages/javalang/java-renderer/build.gradle
+++ b/languages/javalang/java-renderer/build.gradle
@@ -1,4 +1,3 @@
-
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '1.3.41'
 }
@@ -10,6 +9,13 @@ compileTestKotlin {
     kotlinOptions.jvmTarget = "1.8"
 }
 
+publishing {
+    publications {
+        Maven(MavenPublication) {
+            from components.java
+        }
+    }
+}
 
 dependencies {
     compile project(':languages:javalang:java-base')

--- a/languages/php/build.gradle
+++ b/languages/php/build.gradle
@@ -1,7 +1,7 @@
-
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '1.3.41'
 }
+
 compileKotlin {
     kotlinOptions.jvmTarget = "1.8"
 }
@@ -9,6 +9,13 @@ compileTestKotlin {
     kotlinOptions.jvmTarget = "1.8"
 }
 
+publishing {
+    publications {
+        Maven(MavenPublication) {
+            from components.java
+        }
+    }
+}
 
 dependencies {
     compile project(':codegen-renderers')

--- a/languages/typescript/build.gradle
+++ b/languages/typescript/build.gradle
@@ -1,7 +1,7 @@
-
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '1.3.41'
 }
+
 compileKotlin {
     kotlinOptions.jvmTarget = "1.8"
 }
@@ -9,6 +9,13 @@ compileTestKotlin {
     kotlinOptions.jvmTarget = "1.8"
 }
 
+publishing {
+    publications {
+        Maven(MavenPublication) {
+            from components.java
+        }
+    }
+}
 
 dependencies {
     compile project(':codegen-renderers')

--- a/tools/cli-application/build.gradle
+++ b/tools/cli-application/build.gradle
@@ -2,8 +2,6 @@ plugins {
     id 'org.jetbrains.kotlin.jvm' version '1.3.41'
 }
 
-apply plugin: 'com.github.johnrengelman.shadow'
-
 compileKotlin {
     kotlinOptions.jvmTarget = "1.8"
 }
@@ -11,6 +9,15 @@ compileTestKotlin {
     kotlinOptions.jvmTarget = "1.8"
 }
 
+apply plugin: 'com.github.johnrengelman.shadow'
+
+publishing {
+    publications {
+        Maven(MavenPublication) {
+            from components.java
+        }
+    }
+}
 
 dependencies {
     compile project(':codegen-renderers')

--- a/tools/codegen-gradle-plugin/README.md
+++ b/tools/codegen-gradle-plugin/README.md
@@ -1,3 +1,22 @@
+### Fetching our gradle plugin from bintray
+
+The following configuration eanbles using our grdale plugin from bintray:
+
+```groovy
+buildscript {
+    repositories {
+        mavenCentral()
+        jcenter()
+        maven {
+            url  "https://dl.bintray.com/vrapio/vrapio"
+        }
+    }
+    dependencies {
+        classpath "io.vrap.rmf.codegen:codegen-gradle-plugin:$codegen-version"
+    }
+}
+```
+
 ### VRAP Gradle plugin
 
 In order to make the integration of the code generator in a gradle build easy we created a gradle plugin with id
@@ -14,7 +33,7 @@ A target is a generation target it contains
    * target: can be one of `javaModel`, `javaModelWithInterfaces`, `groovyDsl`, `javaSpringClient`, `typescriptModel`, `joiValidator` depending on your target language
    * customTypeMapping: optionally allow you to replace some generated types with hand writen ones
 
-#### building
+#### Building
 
 If you want to build the plugin from the root component run the following command `./gradlew clean build  :tools:codegen-gradle-plugin:shadowJar`
 

--- a/tools/codegen-gradle-plugin/build.gradle
+++ b/tools/codegen-gradle-plugin/build.gradle
@@ -2,12 +2,24 @@ plugins {
     id 'org.jetbrains.kotlin.jvm' version '1.3.41'
 }
 
+compileKotlin {
+    kotlinOptions.jvmTarget = "1.8"
+}
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "1.8"
+}
+
 apply plugin: 'java-gradle-plugin'
 apply plugin: 'com.gradle.plugin-publish'
 apply plugin: 'com.github.johnrengelman.shadow'
 
-
-sourceCompatibility = 1.8
+publishing {
+    publications {
+        Maven(MavenPublication) {
+            from components.java
+        }
+    }
+}
 
 dependencies {
     compile project(':languages:javalang:java-renderer')


### PR DESCRIPTION
**Summary**

This PR enables us to publish our artifacts - including our gradle plugin - to bintray. This then allows us to remove this rather lrage artifact (90 MB) from our projects github repository.

And it still makes sense to publish our plugin to the gradle center, but to me it seems to be easier for now to publish our artifacts to bintray.