### PR TITLE
Add null check to generated spring client for query parameter of enum…

### DIFF
--- a/languages/javalang/java-renderer/src/main/kotlin/io/vrap/codegen/languages/javalang/client/SpringClientRenderer.kt
+++ b/languages/javalang/java-renderer/src/main/kotlin/io/vrap/codegen/languages/javalang/client/SpringClientRenderer.kt
@@ -116,7 +116,7 @@ class SpringClientRenderer @Inject constructor(override val vrapTypeProvider: Vr
                 if (paramType.enum.isEmpty()) {
                     this.name;
                 } else {
-                    "${this.name}.getJsonName()"
+                    "${this.name} == null ? null : ${this.name}.getJsonName()"
                 }
             }
             else -> this.name


### PR DESCRIPTION
Add null check to generated spring client for query parameter of enum type.

This is required for our import-api.