### PR TITLE
Add bintray publish of our cli-application shadowJar to our build.

### DIFF
--- a/tools/cli-application/build.gradle
+++ b/tools/cli-application/build.gradle
@@ -14,7 +14,7 @@ apply plugin: 'com.github.johnrengelman.shadow'
 publishing {
     publications {
         Maven(MavenPublication) {
-            from components.java
+            publication -> project.shadow.component(publication)
         }
     }
 }
@@ -30,6 +30,8 @@ dependencies {
     compile 'com.google.guava:guava:27.0.1-jre'
     compile 'io.airlift:airline:0.8'
 }
+
+tasks.build.dependsOn tasks.shadowJar
 
 shadowJar {
     manifest {


### PR DESCRIPTION
This publishes our `cli-application` as a fat/shadowJar to bintray. The file name will follow the scheme ` cli-application-1.0.0-20200220154205-all.jar`.