### PR TITLE
Use nativeImage to build native executable for cli-application

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ export VRAP_VERSION=1.0.0-20200225111016 && curl -o- -s https://raw.githubuserco
 ```
 You will find a new command available  `rmf-codegen`, you can check that all is good by executing `rmf-codegen -v`
 
+# Build a native executable with GraalVM
+
+You can also build a native executable with the following commands:
+```
+cd tools/cli-application/
+../../gradlew nativeImage
+```
+The native executable can then be found at `build/grall/rmf-codegen`.
+It's currently only tested with Mac OS X.
+
 # Why did we choose kotlin for writing our code generators?
 
 We choose kotlin because of the following features:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You can also build a native executable with the following commands:
 cd tools/cli-application/
 ../../gradlew nativeImage
 ```
-The native executable can then be found at `build/grall/rmf-codegen`.
+The native executable can then be found at `build/graal/rmf-codegen`.
 It's currently only tested with Mac OS X.
 
 # Why did we choose kotlin for writing our code generators?

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ plugins {
     id 'com.gradle.plugin-publish' version '0.9.1'
     id 'org.inferred.processors' version '1.2.16'
     id 'com.github.johnrengelman.shadow' version '4.0.3'
+    id 'com.palantir.graal' version '0.6.0'
 }
 
 ext {

--- a/tools/cli-application/build.gradle
+++ b/tools/cli-application/build.gradle
@@ -13,6 +13,12 @@ compileTestKotlin {
 }
 
 apply plugin: 'com.github.johnrengelman.shadow'
+apply plugin: 'com.palantir.graal'
+
+graal {
+    mainClass 'io.vrap.rmf.codegen.cli.MainKt'
+    outputName 'rmf-codegen'
+}
 
 publishing {
     publications {


### PR DESCRIPTION
Looks like this was much easier then expected with the gradle plugin from palantir 😄 
It only took 30 minutes of my spare time 😎 

I only tested it locally on my MacBook, let's see if it works under linux too.
